### PR TITLE
feat: Add TOTP 2FA support with live code generation

### DIFF
--- a/Sources/UptimeKumaNotifier/Services/SocketIOService.swift
+++ b/Sources/UptimeKumaNotifier/Services/SocketIOService.swift
@@ -6,6 +6,7 @@ protocol SocketIOServiceDelegate: AnyObject {
     func socketService(_ service: SocketIOService, didChangeState state: ServerConnectionState)
     func socketService(_ service: SocketIOService, didReceiveMonitorList monitors: [Int: Monitor])
     func socketService(_ service: SocketIOService, didReceiveHeartbeat heartbeat: Heartbeat)
+    func socketServiceTokenAuthFailed(_ service: SocketIOService)
 }
 
 final class SocketIOService: @unchecked Sendable {
@@ -14,6 +15,8 @@ final class SocketIOService: @unchecked Sendable {
     private let serverConfig: Server
     private weak var delegate: (any SocketIOServiceDelegate)?
     private var storedPassword: String?
+    private var tokenAuthTimer: DispatchWorkItem?
+    private var tokenAuthSucceeded = false
 
     init(server: Server, delegate: any SocketIOServiceDelegate) {
         self.serverConfig = server
@@ -131,6 +134,8 @@ final class SocketIOService: @unchecked Sendable {
     }
 
     func disconnect() {
+        tokenAuthTimer?.cancel()
+        tokenAuthTimer = nil
         socket?.disconnect()
         socket?.removeAllHandlers()
         manager?.disconnect()
@@ -149,10 +154,21 @@ final class SocketIOService: @unchecked Sendable {
             self.notifyDelegate(state: .authenticating)
 
             if let token {
-                socket.emit("loginByToken", token) { [weak self] in
-                    // loginByToken doesn't use ack in the same way, we handle via monitorList arrival
-                    _ = self  // prevent unused warning
+                self.tokenAuthSucceeded = false
+                socket.emit("loginByToken", token)
+
+                // loginByToken has no ack — if the token is stale the server
+                // silently ignores it. Set a timeout so we can fall back to
+                // password-based auth.
+                let timeout = DispatchWorkItem { [weak self] in
+                    guard let self, !self.tokenAuthSucceeded else { return }
+                    Task { @MainActor [weak self] in
+                        guard let self, let delegate = self.delegate else { return }
+                        delegate.socketServiceTokenAuthFailed(self)
+                    }
                 }
+                self.tokenAuthTimer = timeout
+                DispatchQueue.main.asyncAfter(deadline: .now() + 10, execute: timeout)
             } else if let twoFactorToken, !twoFactorToken.isEmpty {
                 let loginData: [String: Any] = [
                     "username": username,
@@ -221,6 +237,11 @@ final class SocketIOService: @unchecked Sendable {
 
     private func handleMonitorList(_ data: [Any]) {
         guard let dict = data.first as? [String: Any] else { return }
+
+        // Token auth succeeded — cancel the fallback timer
+        tokenAuthSucceeded = true
+        tokenAuthTimer?.cancel()
+        tokenAuthTimer = nil
 
         var monitors: [Int: Monitor] = [:]
         for (_, value) in dict {

--- a/Sources/UptimeKumaNotifier/Services/TOTPService.swift
+++ b/Sources/UptimeKumaNotifier/Services/TOTPService.swift
@@ -1,0 +1,59 @@
+import CryptoKit
+import Foundation
+
+enum TOTPService {
+    /// Generate a 6-digit TOTP code from a base32-encoded secret.
+    /// Uses SHA1, 30-second time step, 6-digit output per RFC 6238.
+    static func generateCode(secret: String, time: Date = Date()) -> String? {
+        guard let keyData = base32Decode(secret) else { return nil }
+
+        let timeInterval = UInt64(time.timeIntervalSince1970) / 30
+        var counter = timeInterval.bigEndian
+
+        let counterData = withUnsafeBytes(of: &counter) { Data($0) }
+        let key = SymmetricKey(data: keyData)
+        let hmac = HMAC<Insecure.SHA1>.authenticationCode(for: counterData, using: key)
+        let hmacBytes = Array(hmac)
+
+        let offset = Int(hmacBytes[hmacBytes.count - 1] & 0x0F)
+        let truncated =
+            (UInt32(hmacBytes[offset]) & 0x7F) << 24
+            | UInt32(hmacBytes[offset + 1]) << 16
+            | UInt32(hmacBytes[offset + 2]) << 8
+            | UInt32(hmacBytes[offset + 3])
+
+        let code = truncated % 1_000_000
+        return String(format: "%06d", code)
+    }
+
+    // MARK: - Base32 Decoding
+
+    private static let base32Alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
+
+    private static func base32Decode(_ input: String) -> Data? {
+        let cleaned = input.uppercased()
+            .replacingOccurrences(of: " ", with: "")
+            .replacingOccurrences(of: "-", with: "")
+            .replacingOccurrences(of: "=", with: "")
+
+        guard !cleaned.isEmpty else { return nil }
+
+        var bits = 0
+        var accumulator = 0
+        var output = Data()
+
+        for char in cleaned {
+            guard let index = base32Alphabet.firstIndex(of: char) else { return nil }
+            let value = base32Alphabet.distance(from: base32Alphabet.startIndex, to: index)
+            accumulator = (accumulator << 5) | value
+            bits += 5
+
+            if bits >= 8 {
+                bits -= 8
+                output.append(UInt8((accumulator >> bits) & 0xFF))
+            }
+        }
+
+        return output
+    }
+}

--- a/Sources/UptimeKumaNotifier/ViewModels/ServerConnectionViewModel.swift
+++ b/Sources/UptimeKumaNotifier/ViewModels/ServerConnectionViewModel.swift
@@ -47,18 +47,28 @@ final class ServerConnectionViewModel: SocketIOServiceDelegate {
         // Try token-based reconnection first, fall back to password
         let token = (try? KeychainService.getToken(for: server.id)) ?? nil
         let password = (try? KeychainService.getPassword(for: server.id)) ?? nil
-        let twoFactorToken = (try? KeychainService.getTwoFactorToken(for: server.id)) ?? nil
 
         if let token, let password {
             service.connectWithToken(token, password: password)
         } else if let password {
-            if let twoFactorToken, !twoFactorToken.isEmpty {
-                service.connectWithTwoFactor(password: password, twoFactorToken: twoFactorToken)
-            } else {
-                service.connect(password: password)
-            }
+            connectWithPassword(service: service, password: password)
         } else {
             connectionState = .error("No credentials found")
+        }
+    }
+
+    /// Connect using password, generating a live TOTP code if a 2FA secret is stored.
+    private func connectWithPassword(service: SocketIOService, password: String) {
+        let twoFactorSecret = (try? KeychainService.getTwoFactorToken(for: server.id)) ?? nil
+
+        if let secret = twoFactorSecret, !secret.isEmpty {
+            if let code = TOTPService.generateCode(secret: secret) {
+                service.connectWithTwoFactor(password: password, twoFactorToken: code)
+            } else {
+                connectionState = .error("Invalid 2FA secret — could not generate code")
+            }
+        } else {
+            service.connect(password: password)
         }
     }
 
@@ -82,6 +92,21 @@ final class ServerConnectionViewModel: SocketIOServiceDelegate {
         if case .error = state {
             try? KeychainService.deleteToken(for: server.id)
         }
+    }
+
+    func socketServiceTokenAuthFailed(_ service: SocketIOService) {
+        // Stale JWT token — clear it and reconnect with password
+        try? KeychainService.deleteToken(for: server.id)
+        service.disconnect()
+
+        guard let password = (try? KeychainService.getPassword(for: server.id)) ?? nil else {
+            connectionState = .error("Token expired and no password available")
+            return
+        }
+
+        let newService = SocketIOService(server: server, delegate: self)
+        self.socketService = newService
+        connectWithPassword(service: newService, password: password)
     }
 
     func socketService(_ service: SocketIOService, didReceiveMonitorList newMonitors: [Int: Monitor]) {

--- a/Sources/UptimeKumaNotifier/Views/ServerFormView.swift
+++ b/Sources/UptimeKumaNotifier/Views/ServerFormView.swift
@@ -33,9 +33,8 @@ struct ServerFormView: View {
                     .textFieldStyle(.roundedBorder)
                     .textContentType(.password)
 
-                TextField("2FA Token (optional)", text: $twoFactorToken)
+                SecureField("2FA Secret (optional)", text: $twoFactorToken)
                     .textFieldStyle(.roundedBorder)
-                    .textContentType(.oneTimeCode)
             } header: {
                 Text(isNew ? "Add Server" : "Edit Server")
                     .font(.headline)


### PR DESCRIPTION
- Implement TOTPService for RFC 6238 2FA code generation
- Use TOTP codes when 2FA secret is stored in Keychain
- Fallback to password auth if token auth fails
- Update ServerFormView to accept 2FA secret securely
