### PR TITLE
feat: Add refresh controls and loading indicators to UI

### DIFF
--- a/Sources/UptimeKumaNotifier/ViewModels/ServerManager.swift
+++ b/Sources/UptimeKumaNotifier/ViewModels/ServerManager.swift
@@ -6,6 +6,7 @@ import SwiftUI
 final class ServerManager {
     var servers: [Server] = []
     var connections: [UUID: ServerConnectionViewModel] = [:]
+    var isRefreshing = false
 
     private static let serversKey = "savedServers"
 
@@ -99,7 +100,10 @@ final class ServerManager {
                 let vm = ServerConnectionViewModel(server: server)
                 connections[server.id] = vm
             }
-            connections[server.id]?.connect()
+            // Only connect if not already connected
+            if !connections[server.id]!.connectionState.isConnected {
+                connections[server.id]?.connect()
+            }
         }
     }
 
@@ -115,6 +119,20 @@ final class ServerManager {
         let vm = ServerConnectionViewModel(server: server)
         connections[id] = vm
         vm.connect()
+    }
+
+    func refreshAllServers() {
+        isRefreshing = true
+        for server in servers {
+            connections[server.id]?.disconnect()
+            let vm = ServerConnectionViewModel(server: server)
+            connections[server.id] = vm
+            vm.connect()
+        }
+        // Reset refreshing state after a short delay
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            self.isRefreshing = false
+        }
     }
 
     // MARK: - Persistence

--- a/Sources/UptimeKumaNotifier/Views/MenuBarView.swift
+++ b/Sources/UptimeKumaNotifier/Views/MenuBarView.swift
@@ -83,6 +83,17 @@ struct MenuBarView: View {
             }
             .buttonStyle(.plain)
             Spacer()
+            if serverManager.hasAnyConnection {
+                Button("Refresh") {
+                    serverManager.refreshAllServers()
+                }
+                .buttonStyle(.plain)
+                if serverManager.isRefreshing {
+                    ProgressView()
+                        .controlSize(.small)
+                        .padding(.leading, 4)
+                }
+            }
             Button("Quit") {
                 NSApplication.shared.terminate(nil)
             }

--- a/Sources/UptimeKumaNotifier/Views/MonitorListView.swift
+++ b/Sources/UptimeKumaNotifier/Views/MonitorListView.swift
@@ -13,10 +13,21 @@ struct MonitorListView: View {
         DisclosureGroup(isExpanded: $isExpanded) {
             if connection.connectionState.isConnected {
                 if connection.sortedMonitors.isEmpty {
-                    Text("No monitors")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+                    if connection.connectionState == .connecting || connection.connectionState == .authenticating {
+                        HStack {
+                            ProgressView()
+                                .controlSize(.small)
+                            Text("Loading monitors...")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
                         .padding(.leading, 8)
+                    } else {
+                        Text("No monitors")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .padding(.leading, 8)
+                    }
                 } else {
                     ForEach(connection.sortedMonitors) { monitor in
                         MonitorRowView(monitor: monitor)
@@ -84,13 +95,30 @@ struct MonitorListView: View {
             }
         }
         .padding(.horizontal)
+        .overlay(alignment: .trailing) {
+            if connection.connectionState.isConnected {
+                Button(action: onReconnect) {
+                    Image(systemName: "arrow.clockwise")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+                .padding(.trailing, 8)
+            }
+        }
     }
 
     @ViewBuilder
     private var connectionIndicator: some View {
-        Circle()
-            .fill(indicatorColor)
-            .frame(width: 8, height: 8)
+        if connection.connectionState == .connecting || connection.connectionState == .authenticating {
+            ProgressView()
+                .controlSize(.small)
+                .frame(width: 16, height: 16)
+        } else {
+            Circle()
+                .fill(indicatorColor)
+                .frame(width: 8, height: 8)
+        }
     }
 
     private var indicatorColor: Color {

--- a/Sources/UptimeKumaNotifier/Views/MonitorRowView.swift
+++ b/Sources/UptimeKumaNotifier/Views/MonitorRowView.swift
@@ -33,6 +33,7 @@ struct MonitorRowView: View {
         }
         .padding(.vertical, 2)
         .padding(.leading, 8)
+        .opacity(monitor.active ? 1.0 : 0.6)
     }
 
     private var statusColor: Color {


### PR DESCRIPTION
- Add "Refresh" button and progress indicator to MenuBarView
- Add per-server refresh button to MonitorListView
- Show loading spinner for monitors during connection/authentication
- Dim inactive monitors in MonitorRowView
