### PR TITLE
feat: Preserve monitor data during reconnect and refresh

### DIFF
--- a/Sources/UptimeKumaNotifier/ViewModels/ServerConnectionViewModel.swift
+++ b/Sources/UptimeKumaNotifier/ViewModels/ServerConnectionViewModel.swift
@@ -13,6 +13,16 @@ final class ServerConnectionViewModel: SocketIOServiceDelegate {
         self.server = server
     }
 
+    /// Initialize with existing monitor data (used during refresh)
+    convenience init(server: Server, existingMonitors: [Int: Monitor]) {
+        self.init(server: server)
+        self.monitors = existingMonitors
+        // If we have existing monitors, consider the connection as reconnecting
+        if !existingMonitors.isEmpty {
+            self.connectionState = .connecting
+        }
+    }
+
     var upCount: Int {
         monitors.values.filter { $0.active && $0.status == .up }.count
     }

--- a/Sources/UptimeKumaNotifier/ViewModels/ServerManager.swift
+++ b/Sources/UptimeKumaNotifier/ViewModels/ServerManager.swift
@@ -97,6 +97,7 @@ final class ServerManager {
     func connectAll() {
         for server in servers {
             if connections[server.id] == nil {
+                // No existing connection, create a new one
                 let vm = ServerConnectionViewModel(server: server)
                 connections[server.id] = vm
             }
@@ -115,8 +116,10 @@ final class ServerManager {
 
     func reconnectServer(id: UUID) {
         guard let server = servers.first(where: { $0.id == id }) else { return }
+        // Preserve existing monitor data during reconnect
+        let existingMonitors = connections[id]?.monitors ?? [:]
         connections[id]?.disconnect()
-        let vm = ServerConnectionViewModel(server: server)
+        let vm = ServerConnectionViewModel(server: server, existingMonitors: existingMonitors)
         connections[id] = vm
         vm.connect()
     }
@@ -124,8 +127,11 @@ final class ServerManager {
     func refreshAllServers() {
         isRefreshing = true
         for server in servers {
+            // Preserve existing monitor data during refresh
+            let existingMonitors = connections[server.id]?.monitors ?? [:]
             connections[server.id]?.disconnect()
-            let vm = ServerConnectionViewModel(server: server)
+            // Use convenience initializer to preserve monitor data and set proper connection state
+            let vm = ServerConnectionViewModel(server: server, existingMonitors: existingMonitors)
             connections[server.id] = vm
             vm.connect()
         }

--- a/Sources/UptimeKumaNotifier/Views/MonitorListView.swift
+++ b/Sources/UptimeKumaNotifier/Views/MonitorListView.swift
@@ -95,17 +95,6 @@ struct MonitorListView: View {
             }
         }
         .padding(.horizontal)
-        .overlay(alignment: .trailing) {
-            if connection.connectionState.isConnected {
-                Button(action: onReconnect) {
-                    Image(systemName: "arrow.clockwise")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-                .buttonStyle(.plain)
-                .padding(.trailing, 8)
-            }
-        }
     }
 
     @ViewBuilder
@@ -124,15 +113,25 @@ struct MonitorListView: View {
     private var indicatorColor: Color {
         switch connection.connectionState {
         case .connected:
-            connection.downCount > 0 ? .red : .green
+            return connection.downCount > 0 ? .red : .green
         case .connecting, .authenticating:
-            .yellow
+            // If we have monitor data during reconnection, show the appropriate color
+            if !connection.sortedMonitors.isEmpty {
+                return connection.downCount > 0 ? .red : .green
+            } else {
+                return .yellow
+            }
         case .disconnected:
-            .gray
+            // If we have monitor data but are disconnected, show the last known status
+            if !connection.sortedMonitors.isEmpty {
+                return connection.downCount > 0 ? .red : .green
+            } else {
+                return .gray
+            }
         case .twoFactorRequired:
-            .yellow
+            return .yellow
         case .error:
-            .red
+            return .red
         }
     }
 


### PR DESCRIPTION
- Add ServerConnectionViewModel initializer to accept existing monitors
- Update ServerManager to retain monitor state on reconnect/refresh
- Adjust MonitorListView indicator to reflect last known status during
  reconnects
