### PR TITLE
feat: Add refreshing state to server connection handling

### DIFF
--- a/Sources/UptimeKumaNotifier/Models/ServerConnectionState.swift
+++ b/Sources/UptimeKumaNotifier/Models/ServerConnectionState.swift
@@ -5,6 +5,7 @@ enum ServerConnectionState: Sendable, Equatable {
     case connecting
     case authenticating
     case connected
+    case refreshing
     case twoFactorRequired
     case error(String)
 
@@ -14,6 +15,7 @@ enum ServerConnectionState: Sendable, Equatable {
         case .connecting: "Connecting..."
         case .authenticating: "Authenticating..."
         case .connected: "Connected"
+        case .refreshing: "Refreshing..."
         case .twoFactorRequired: "2FA Required"
         case .error(let msg): "Error: \(msg)"
         }
@@ -21,6 +23,7 @@ enum ServerConnectionState: Sendable, Equatable {
 
     var isConnected: Bool {
         if case .connected = self { return true }
+        if case .refreshing = self { return true }
         return false
     }
 }

--- a/Sources/UptimeKumaNotifier/ViewModels/ServerConnectionViewModel.swift
+++ b/Sources/UptimeKumaNotifier/ViewModels/ServerConnectionViewModel.swift
@@ -17,9 +17,9 @@ final class ServerConnectionViewModel: SocketIOServiceDelegate {
     convenience init(server: Server, existingMonitors: [Int: Monitor]) {
         self.init(server: server)
         self.monitors = existingMonitors
-        // If we have existing monitors, consider the connection as reconnecting
+        // If we have existing monitors, consider the connection as refreshing
         if !existingMonitors.isEmpty {
-            self.connectionState = .connecting
+            self.connectionState = .refreshing
         }
     }
 

--- a/Sources/UptimeKumaNotifier/Views/MonitorListView.swift
+++ b/Sources/UptimeKumaNotifier/Views/MonitorListView.swift
@@ -103,6 +103,12 @@ struct MonitorListView: View {
             ProgressView()
                 .controlSize(.small)
                 .frame(width: 16, height: 16)
+        } else if connection.connectionState == .refreshing {
+            // Show a refresh indicator during refresh
+            Image(systemName: "arrow.clockwise")
+                .foregroundStyle(indicatorColor)
+                .font(.caption)
+                .frame(width: 16, height: 16)
         } else {
             Circle()
                 .fill(indicatorColor)
@@ -113,6 +119,9 @@ struct MonitorListView: View {
     private var indicatorColor: Color {
         switch connection.connectionState {
         case .connected:
+            return connection.downCount > 0 ? .red : .green
+        case .refreshing:
+            // During refresh, show the status based on existing monitor data
             return connection.downCount > 0 ? .red : .green
         case .connecting, .authenticating:
             // If we have monitor data during reconnection, show the appropriate color


### PR DESCRIPTION
- Introduce .refreshing to ServerConnectionState
- Update ServerConnectionViewModel to use .refreshing when reconnecting
  with existing monitors
- Show refresh indicator in MonitorListView during refresh
- Adjust indicator color logic to handle refreshing state
