### PR TITLE
refactor: remove ServerConnectionState.refreshing and update refresh logic

### DIFF
--- a/Sources/UptimeKumaNotifier/Models/ServerConnectionState.swift
+++ b/Sources/UptimeKumaNotifier/Models/ServerConnectionState.swift
@@ -5,7 +5,6 @@ enum ServerConnectionState: Sendable, Equatable {
     case connecting
     case authenticating
     case connected
-    case refreshing
     case twoFactorRequired
     case error(String)
 
@@ -15,7 +14,6 @@ enum ServerConnectionState: Sendable, Equatable {
         case .connecting: "Connecting..."
         case .authenticating: "Authenticating..."
         case .connected: "Connected"
-        case .refreshing: "Refreshing..."
         case .twoFactorRequired: "2FA Required"
         case .error(let msg): "Error: \(msg)"
         }
@@ -23,7 +21,6 @@ enum ServerConnectionState: Sendable, Equatable {
 
     var isConnected: Bool {
         if case .connected = self { return true }
-        if case .refreshing = self { return true }
         return false
     }
 }

--- a/Sources/UptimeKumaNotifier/ViewModels/ServerConnectionViewModel.swift
+++ b/Sources/UptimeKumaNotifier/ViewModels/ServerConnectionViewModel.swift
@@ -13,15 +13,7 @@ final class ServerConnectionViewModel: SocketIOServiceDelegate {
         self.server = server
     }
 
-    /// Initialize with existing monitor data (used during refresh)
-    convenience init(server: Server, existingMonitors: [Int: Monitor]) {
-        self.init(server: server)
-        self.monitors = existingMonitors
-        // If we have existing monitors, consider the connection as refreshing
-        if !existingMonitors.isEmpty {
-            self.connectionState = .refreshing
-        }
-    }
+
 
     var upCount: Int {
         monitors.values.filter { $0.active && $0.status == .up }.count

--- a/Sources/UptimeKumaNotifier/ViewModels/ServerManager.swift
+++ b/Sources/UptimeKumaNotifier/ViewModels/ServerManager.swift
@@ -7,6 +7,7 @@ final class ServerManager {
     var servers: [Server] = []
     var connections: [UUID: ServerConnectionViewModel] = [:]
     var isRefreshing = false
+    var lastKnownMonitors: [UUID: [Int: Monitor]] = [:]
 
     private static let serversKey = "savedServers"
 
@@ -116,27 +117,28 @@ final class ServerManager {
 
     func reconnectServer(id: UUID) {
         guard let server = servers.first(where: { $0.id == id }) else { return }
-        // Preserve existing monitor data during reconnect
-        let existingMonitors = connections[id]?.monitors ?? [:]
         connections[id]?.disconnect()
-        let vm = ServerConnectionViewModel(server: server, existingMonitors: existingMonitors)
+        let vm = ServerConnectionViewModel(server: server)
         connections[id] = vm
         vm.connect()
     }
 
     func refreshAllServers() {
+        // Store last known monitor data before refreshing
+        for server in servers {
+            lastKnownMonitors[server.id] = connections[server.id]?.monitors ?? [:]
+        }
+
         isRefreshing = true
         for server in servers {
-            // Preserve existing monitor data during refresh
-            let existingMonitors = connections[server.id]?.monitors ?? [:]
+            // Force reconnect to get fresh data
             connections[server.id]?.disconnect()
-            // Use convenience initializer to preserve monitor data and set proper connection state
-            let vm = ServerConnectionViewModel(server: server, existingMonitors: existingMonitors)
+            let vm = ServerConnectionViewModel(server: server)
             connections[server.id] = vm
             vm.connect()
         }
         // Reset refreshing state after a short delay
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
             self.isRefreshing = false
         }
     }

--- a/Sources/UptimeKumaNotifier/Views/MenuBarView.swift
+++ b/Sources/UptimeKumaNotifier/Views/MenuBarView.swift
@@ -64,6 +64,7 @@ struct MenuBarView: View {
                             MonitorListView(
                                 server: server,
                                 connection: connection,
+                                serverManager: serverManager,
                                 onReconnect: { serverManager.reconnectServer(id: server.id) },
                                 onSubmitTwoFactor: { code in connection.submitTwoFactorCode(code) }
                             )

--- a/Sources/UptimeKumaNotifier/Views/MonitorListView.swift
+++ b/Sources/UptimeKumaNotifier/Views/MonitorListView.swift
@@ -3,33 +3,41 @@ import SwiftUI
 struct MonitorListView: View {
     let server: Server
     let connection: ServerConnectionViewModel
+    let serverManager: ServerManager
     let onReconnect: () -> Void
     let onSubmitTwoFactor: (String) -> Void
 
     @State private var isExpanded = true
     @State private var twoFactorCode = ""
 
+    private var monitorsToDisplay: [Int: Monitor] {
+        if serverManager.isRefreshing, let lastKnown = serverManager.lastKnownMonitors[server.id] {
+            return lastKnown
+        }
+        return connection.monitors
+    }
+
+    private var sortedMonitorsToDisplay: [Monitor] {
+        monitorsToDisplay.values
+            .filter { $0.active }
+            .sorted { lhs, rhs in
+                if lhs.status != rhs.status {
+                    return lhs.status.rawValue < rhs.status.rawValue
+                }
+                return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+            }
+    }
+
     var body: some View {
         DisclosureGroup(isExpanded: $isExpanded) {
             if connection.connectionState.isConnected {
-                if connection.sortedMonitors.isEmpty {
-                    if connection.connectionState == .connecting || connection.connectionState == .authenticating {
-                        HStack {
-                            ProgressView()
-                                .controlSize(.small)
-                            Text("Loading monitors...")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        }
+                if sortedMonitorsToDisplay.isEmpty {
+                    Text("No monitors")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
                         .padding(.leading, 8)
-                    } else {
-                        Text("No monitors")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                            .padding(.leading, 8)
-                    }
                 } else {
-                    ForEach(connection.sortedMonitors) { monitor in
+                    ForEach(sortedMonitorsToDisplay) { monitor in
                         MonitorRowView(monitor: monitor)
                     }
                 }
@@ -103,12 +111,6 @@ struct MonitorListView: View {
             ProgressView()
                 .controlSize(.small)
                 .frame(width: 16, height: 16)
-        } else if connection.connectionState == .refreshing {
-            // Show a refresh indicator during refresh
-            Image(systemName: "arrow.clockwise")
-                .foregroundStyle(indicatorColor)
-                .font(.caption)
-                .frame(width: 16, height: 16)
         } else {
             Circle()
                 .fill(indicatorColor)
@@ -116,27 +118,18 @@ struct MonitorListView: View {
         }
     }
 
+    private var downCountToDisplay: Int {
+        monitorsToDisplay.values.filter { $0.active && $0.status == .down }.count
+    }
+
     private var indicatorColor: Color {
         switch connection.connectionState {
         case .connected:
-            return connection.downCount > 0 ? .red : .green
-        case .refreshing:
-            // During refresh, show the status based on existing monitor data
-            return connection.downCount > 0 ? .red : .green
+            return downCountToDisplay > 0 ? .red : .green
         case .connecting, .authenticating:
-            // If we have monitor data during reconnection, show the appropriate color
-            if !connection.sortedMonitors.isEmpty {
-                return connection.downCount > 0 ? .red : .green
-            } else {
-                return .yellow
-            }
+            return .yellow
         case .disconnected:
-            // If we have monitor data but are disconnected, show the last known status
-            if !connection.sortedMonitors.isEmpty {
-                return connection.downCount > 0 ? .red : .green
-            } else {
-                return .gray
-            }
+            return .gray
         case .twoFactorRequired:
             return .yellow
         case .error:


### PR DESCRIPTION
- Remove `.refreshing` case from `ServerConnectionState`
- Simplify ServerConnectionViewModel initializers
- Track last known monitor data in ServerManager during refresh
- Update MonitorListView to display last known monitors while refreshing
- Adjust status indicator and monitor list logic for new refresh flow
